### PR TITLE
fixed shebang line and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ fwaudit does not currently have any packaging, or standard installation director
 
 ## Usage
 
-$ sudo python2 ./fwaudit.py -h
+The help and --list_tools options can be run without sudo:
+
+$ ./fwaudit.py -h
 
 Gives:
 
@@ -142,6 +144,12 @@ optional arguments:
                         Specify how to log tool output.
   -c, --colorize        Use colored output for interactive console.
   --hash                Generate SHA256 sidecar hash files for all files.
+
+$ ./fwaudit.py --list_tools
+
+Running a tool requires sudo:
+
+$ sudo ./fwaudit.py -t lsusb
 
 ## Updates & Discussion
 

--- a/fwaudit.py
+++ b/fwaudit.py
@@ -1,4 +1,4 @@
-##!usr/bin/env python2
+#!/usr/bin/env python2
 # -*- coding: UTF-8 -*-
 # vim: set expandtab sw=4 :
 


### PR DESCRIPTION
I'm not sure what previous shebang line was supposed to do, but a more conventional one seems to work better.

Updated README.md to change invocation instructions, and note that one can do -h and --list_tools without root.